### PR TITLE
Update titleText in c.OnHTML from search.go file

### DIFF
--- a/search.go
+++ b/search.go
@@ -305,7 +305,7 @@ func Search(ctx context.Context, searchTerm string, opts ...SearchOptions) ([]Re
 
 		linkHref, _ := sel.Find("a").Attr("href")
 		linkText := strings.TrimSpace(linkHref)
-		titleText := strings.TrimSpace(sel.Find("div > div > a > h3 > span").Text())
+		titleText := strings.TrimSpace(sel.Find("div > div > a > h3").Text())
 
 		descText := strings.TrimSpace(sel.Find("div > div > div > span > span").Text())
 


### PR DESCRIPTION
I had make this change because the Title value of struct Result was not working. The application get element 'span' but the correct is 'h3' element that must be set.

Issue: https://github.com/rocketlaunchr/google-search/issues/6