### PR TITLE
fix/searchResult

### DIFF
--- a/search.go
+++ b/search.go
@@ -335,7 +335,7 @@ func Search(ctx context.Context, searchTerm string, opts ...SearchOptions) ([]Re
 
 		linkHref, _ := sel.Find("a").Attr("href")
 		linkText := strings.TrimSpace(linkHref)
-		titleText := strings.TrimSpace(sel.Find("div > div > div > a > h3").Text())
+		titleText := strings.TrimSpace(sel.Find("div > div > div > div > span > a > h3").Text())
 		descText := strings.TrimSpace(sel.Find("div > div > div > div:first-child > span:first-child").Text())
 
 		rank += 1


### PR DESCRIPTION
The search result was empty because the code dont appent the object found if  link or title is blank or #

```
		if linkText != "" && linkText != "#" && titleText != "" {
			result := Result{
				Rank:        filteredRank,
				URL:         linkText,
				Title:       titleText,
				Description: descText,
			}
			results = append(results, result)
			filteredRank += 1
		}
```

After debug the code i found that the titleText wasn't found, so i change the htmlElements structure

```
titleText := strings.TrimSpace(sel.Find("div > div > div > div > span > a > h3").Text())
```
